### PR TITLE
Add component llvm-tools-preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ $ git clone https://github.com/BurtonQin/rust-lock-bug-detector.git
 $ cd rust-lock-bug-detector
 $ rustup component add rust-src
 $ rustup component add rustc-dev
+$ rustup component add llvm-tools-preview
 $ cargo install --path .
-$ export LD_LIBRARY_PATH=$HOME/.rustup/toolchains/nightly-2021-01-13-x86_64-unknown-linux-gnu/lib:$LD_LIBRARY_PATH
 ```
 
 ## Example

--- a/examples/intra/src/main.rs
+++ b/examples/intra/src/main.rs
@@ -3,7 +3,7 @@ use parking_lot;
 
 fn std_mutex() {
     let mu1 = sync::Mutex::new(1);
-    match *mu1.lock().unwrap() {
+    match *mu1.lock().ok().unwrap() {
         1 => {},
         _ => { *mu1.lock().unwrap() += 1; },
     };

--- a/run.sh
+++ b/run.sh
@@ -11,8 +11,8 @@ fi
 cargo build --release
 export RUSTC=${PWD}/target/release/rust-lock-bug-detector
 export RUST_BACKTRACE=full
-export RUST_LOCK_DETECTOR_TYPE=DoubleLockDetector
-#export RUST_LOCK_DETECTOR_TYPE=ConflictLockDetector
+#export RUST_LOCK_DETECTOR_TYPE=DoubleLockDetector
+export RUST_LOCK_DETECTOR_TYPE=ConflictLockDetector
 export RUST_LOCK_DETECTOR_BLACK_LISTS="cc"
 #export RUST_LOCK_DETECTOR_WHITE_LISTS="inter,intra,static_ref"
 


### PR DESCRIPTION
Replace the original LD_LIBRARY_PATH setting with 
"rustup component add llvm-tools-preview"

Fix link error "/usr/bin/ld: cannot find -lLLVM-11-rust-1.51.0-nightly" in issue #8 